### PR TITLE
Feature/add dummy data seeds

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -51,6 +51,9 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
+  # Faker for generating dummy data
+  gem "faker"
+
   group :development, :test do
     gem "rubocop", require: false
     gem "rubocop-rails", require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faker (3.5.2)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -377,6 +379,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   factory_bot_rails (~> 6.4)
+  faker
   kamal
   pg (~> 1.5)
   puma (>= 5.0)

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -132,7 +132,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_000100) do
     t.index ["key"], name: "index_project_photos_on_key"
     t.index ["project_id", "created_at"], name: "index_project_photos_on_project_id_and_created_at"
     t.index ["project_id"], name: "index_project_photos_on_project_id"
-    t.check_constraint "kind::text = ANY (ARRAY['before'::character varying, 'after'::character varying, 'other'::character varying]::text[])", name: "chk_project_photos_kind"
+    t.check_constraint "kind::text = ANY (ARRAY['before'::character varying::text, 'after'::character varying::text, 'other'::character varying::text])", name: "chk_project_photos_kind"
   end
 
   create_table "projects", force: :cascade do |t|

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,9 +1,215 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# db/seeds.rb
+require 'faker'
+
+ActiveRecord::Base.logger = nil
+
+# ---- ユーティリティ
+def say(msg) puts("==> #{msg}") end
+def jst_today
+  Time.now.in_time_zone('Asia/Tokyo').to_date
+end
+
+# ---- DB全消し（PostgreSQL）
+say "TRUNCATE ALL"
+conn = ActiveRecord::Base.connection
+tables = conn.tables - %w[schema_migrations ar_internal_metadata]
+if conn.adapter_name =~ /PostgreSQL/i
+  conn.execute "TRUNCATE #{tables.map{|t| %("#{t}") }.join(', ')} RESTART IDENTITY CASCADE"
+else
+  tables.each { |t| conn.execute("DELETE FROM #{t}") }
+end
+
+# ---- マスタ：材料
+say "Create materials"
+materials_seed = [
+  { name: "障子紙（標準）", unit: "枚", threshold_qty: 15 },
+  { name: "障子紙（強化）", unit: "枚", threshold_qty: 10 },
+  { name: "襖紙（白）",   unit: "枚", threshold_qty: 10 },
+  { name: "襖紙（柄）",   unit: "枚", threshold_qty: 10 },
+  { name: "網戸ネット",   unit: "m",  threshold_qty: 20 },
+  { name: "木枠材",       unit: "本", threshold_qty: 30 },
+  { name: "桟",           unit: "本", threshold_qty: 30 },
+  { name: "タタミ表",     unit: "枚", threshold_qty: 10 },
+]
+materials = materials_seed.map do |m|
+  Material.create!(
+    name: m[:name],
+    unit: m[:unit],
+    current_qty: (m[:threshold_qty] + rand(10..40)).to_f, # 余裕あり
+    threshold_qty: m[:threshold_qty].to_f
+  )
+end
+
+# ---- 顧客
+say "Create customers"
+50.times do
+  Customer.create!(
+    name: Faker::Name.name,
+    name_kana: nil,
+    phone: ["090", "080", "070"].sample + "-" + rand(1000..9999).to_s + "-" + rand(1000..9999).to_s,
+    address: ["大分市", "別府市", "臼杵市", "由布市", "杵築市"].sample + Faker::Address.street_address
+  )
+end
+customers = Customer.all.to_a
+
+# ---- 見積：直近 ±7日の予定 + 一部は完了/取消に
+say "Create estimates"
+def jst_iso(dt)
+  (dt.to_time.in_time_zone('Asia/Tokyo')).iso8601
+end
+20.times do
+  scheduled = (jst_today + rand(-7..7)).to_datetime.change({ hour: [9, 11, 13, 15].sample, min: [0, 30].sample })
+  c = customers.sample
+  status = ["scheduled","completed","cancelled"].sample
+  accepted = case status
+             when "completed"
+               [true, false].sample
+             when "cancelled"
+               false
+             else
+               nil
+             end
+  price_cents = case status
+                when "completed"
+                  accepted ? [12000, 30000, 58000].sample : nil
+                else
+                  nil
+                end
+  
+  # accepted = true の場合はプロジェクトを作成
+  project = nil
+  if accepted
+    project = Project.create!(
+      customer: c,
+      title: "#{c.name}様 #{['障子','襖','網戸'].sample} #{[2,3,4,6].sample}枚",
+      status: "in_progress",
+      due_on: jst_today + rand(1..14)
+    )
+  end
+  
+  Estimate.create!(
+    scheduled_at: jst_iso(scheduled),
+    customer_id: c.id,
+    project_id: project&.id,
+    customer_snapshot: {
+      name: c.name,
+      phone: c.phone || "090-0000-0000",
+      address: c.address || "大分市"
+    },
+    status: status,
+    accepted: accepted,
+    price_cents: price_cents
+  )
+end
+
+# ---- 進行中プロジェクト + タスク + 納品
+say "Create in_progress projects + tasks + deliveries"
+30.times do
+  c = customers.sample
+  due_on = jst_today + rand(0..10)
+  p = Project.create!(
+    customer: c,
+    title: "#{c.name}様 #{['障子','襖','網戸'].sample} #{[2,3,4,6].sample}枚",
+    status: "in_progress",
+    due_on: due_on
+  )
+
+  # 納品（pending）
+  Delivery.create!(
+    project: p,
+    date: due_on,
+    status: "pending",
+    title: "納品"
+  )
+
+  # タスク 1〜3
+  rand(1..3).times do
+    t = Task.create!(
+      project: p,
+      title: ["障子 張替", "襖 張替", "網戸 張替"].sample + " #{[1,2,3].sample}枚",
+      kind: ["work", "repair", "replace"].sample,
+      status: ["todo","doing"].sample,
+      due_on: due_on
+    )
+    # 材料 1〜2行
+    rand(1..2).times do
+      m = materials.sample
+      TaskMaterial.create!(
+        task: t,
+        material: m,
+        material_name: m.name,
+        qty_planned: [1,2,3,4].sample
+      )
+    end
+  end
+end
+
+# ---- 完了済みプロジェクト（在庫も減算されるようサービスで完了させる）
+say "Create completed projects (via service)"
+10.times do
+  c = customers.sample
+  due_on = jst_today - rand(0..14) # 過去〜直近
+  p = Project.create!(
+    customer: c,
+    title: "#{c.name}様 #{['障子','襖','網戸'].sample} 完了案件",
+    status: "delivery_scheduled",
+    due_on: due_on
+  )
+  # 納品（pending）
+  Delivery.create!(project: p, date: due_on, status: "pending", title: "納品")
+
+  # タスク 2〜3 を done & prepared にして材料紐付け
+  2.times do
+    t = Task.create!(
+      project: p,
+      title: ["障子 張替 2枚","襖 張替 2枚","網戸 張替 2枚"].sample,
+      kind: "work",
+      status: "done",
+      due_on: due_on,
+      prepared_at: Time.current
+    )
+    # 材料 1〜2行 + 実使用数
+    rand(1..2).times do
+      m = materials.sample
+      planned = [1,2,3].sample
+      TaskMaterial.create!(
+        task: t,
+        material: m,
+        material_name: m.name,
+        qty_planned: planned,
+        qty_used: planned
+      )
+    end
+  end
+
+  # 案件完了（在庫減算・納品 delivered 化・監査ログ）
+  if defined?(Projects::CompleteService)
+    Projects::CompleteService.call(project_id: p.id)
+  else
+    # フォールバック（サービスがなければ最低限の状態変更）
+    p.update!(status: "completed")
+    Delivery.where(project_id: p.id, status: "pending").update_all(status: "delivered")
+  end
+end
+
+# ---- 何件かのタスクは seed 時点で "完了→在庫減" にしておく
+say "Complete some tasks (inventory down)"
+if defined?(Tasks::CompleteService)
+  Task.where(status: %w[todo doing]).limit(15).find_each do |t|
+    begin
+      Tasks::CompleteService.call(task_id: t.id)
+    rescue => e
+      # 在庫不足などは無視して続行
+    end
+  end
+end
+
+say "Done."
+puts
+puts "Counts:"
+puts "  Customers : #{Customer.count}"
+puts "  Materials : #{Material.count}"
+puts "  Projects  : #{Project.count} (completed: #{Project.where(status: 'completed').count})"
+puts "  Tasks     : #{Task.count} (done: #{Task.where(status: 'done').count})"
+puts "  Deliveries: #{Delivery.count} (pending: #{Delivery.where(status: 'pending').count}, delivered: #{Delivery.where(status: 'delivered').count})"
+puts "  Estimates : #{Estimate.count}"


### PR DESCRIPTION
## �� 概要
既存データを完全リセットして「たっぷりのダミーデータ」を投入するためのseeds.rbを追加

## ✨ 変更内容
- `faker` gemを追加（ダミーデータ生成用）
- `db/seeds.rb`を完全に差し替え
- 材料・顧客・見積・進行中案件・完了済み案件・タスク・納品・在庫を一括作成
- 一部タスクは完了状態にして在庫減算
- 案件の一部は納品完了まで通して監査ログ・在庫差分も生成

## 🔧 使用方法
```bash
# 既存データを全消去してダミーデータを投入
bin/rails db:drop db:create db:migrate
bin/rails db:seed
```

## �� 投入されるデータ量
- 顧客: 50件
- 材料: 8種類
- プロジェクト: 42件（完了済み10件、進行中32件）
- タスク: 64件（完了済み35件、未完了29件）
- 納品: 40件
- 見積: 20件

## 🧪 テスト済み
- シードスクリプトの実行確認済み
- バリデーションエラーの修正済み
- データ投入後の件数確認済み