### PR TITLE
fix: 見積もり材料入力と在庫チェックの改善

### DIFF
--- a/backend/app/services/inventory/check_task_materials.rb
+++ b/backend/app/services/inventory/check_task_materials.rb
@@ -2,8 +2,16 @@ module Inventory
   class CheckTaskMaterials
     Result = Struct.new(:stock_sufficient, :insufficient_materials, :unregistered_materials, keyword_init: true)
 
-    def self.call(task:)
-      new(task).call
+    def self.call(task: nil, task_ids: nil)
+      if task_ids.present?
+        # 複数タスクの一括チェック
+        task_ids.map { |id| call(task: Task.find(id)) }
+      elsif task.present?
+        # 単一タスクのチェック
+        new(task).call
+      else
+        raise ArgumentError, "task または task_ids のいずれかが必要です"
+      end
     end
 
     def initialize(task)

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -19,290 +19,393 @@ else
   tables.each { |t| conn.execute("DELETE FROM #{t}") }
 end
 
-# ---- マスタ：材料
+# ---- マスタ：材料（在庫管理の基本）
 say "Create materials"
 materials_seed = [
-  { name: "障子紙（標準）", unit: "枚", threshold_qty: 15 },
-  { name: "障子紙（強化）", unit: "枚", threshold_qty: 10 },
-  { name: "襖紙（白）",   unit: "枚", threshold_qty: 10 },
-  { name: "襖紙（柄）",   unit: "枚", threshold_qty: 10 },
-  { name: "網戸ネット",   unit: "m",  threshold_qty: 20 },
-  { name: "木枠材",       unit: "本", threshold_qty: 30 },
-  { name: "桟",           unit: "本", threshold_qty: 30 },
-  { name: "タタミ表",     unit: "枚", threshold_qty: 10 },
+  { name: "障子紙（標準）", unit: "枚", threshold_qty: 15.0, current_qty: 25.0 },
+  { name: "障子紙（強化）", unit: "枚", threshold_qty: 10.0, current_qty: 18.0 },
+  { name: "襖紙（白）",   unit: "枚", threshold_qty: 10.0, current_qty: 20.0 },
+  { name: "襖紙（柄）",   unit: "枚", threshold_qty: 10.0, current_qty: 22.0 },
+  { name: "網戸ネット",   unit: "m",  threshold_qty: 20.0, current_qty: 35.0 },
+  { name: "木枠材",       unit: "本", threshold_qty: 30.0, current_qty: 50.0 },
+  { name: "桟",           unit: "本", threshold_qty: 30.0, current_qty: 45.0 },
+  { name: "タタミ表",     unit: "枚", threshold_qty: 10.0, current_qty: 15.0 },
+  { name: "カーテンレール", unit: "本", threshold_qty: 8.0, current_qty: 12.0 },
+  { name: "カーテン生地",   unit: "m",  threshold_qty: 25.0, current_qty: 40.0 },
 ]
+
 materials = materials_seed.map do |m|
   Material.create!(
     name: m[:name],
     unit: m[:unit],
-    current_qty: (m[:threshold_qty] + rand(10..40)).to_f, # 余裕あり
-    threshold_qty: m[:threshold_qty].to_f
+    current_qty: m[:current_qty],
+    threshold_qty: m[:threshold_qty]
   )
 end
 
-# ---- 顧客
+# ---- 顧客（基本情報）
 say "Create customers"
+customers = []
 50.times do
-  Customer.create!(
+  customer = Customer.create!(
     name: Faker::Name.name,
     name_kana: nil,
     phone: ["090", "080", "070"].sample + "-" + rand(1000..9999).to_s + "-" + rand(1000..9999).to_s,
-    address: ["大分市", "別府市", "臼杵市", "由布市", "杵築市"].sample + Faker::Address.street_address
+    address: ["大分市", "別府市", "臼杵市", "由布市", "杵築市", "豊後高田市", "日田市", "中津市"].sample + Faker::Address.street_address
   )
+  customers << customer
 end
-customers = Customer.all.to_a
 
-# ---- 見積：直近 ±7日の予定 + 一部は完了/取消に
+# ---- 見積（現在の規格に準拠）
 say "Create estimates"
 def jst_iso(dt)
   (dt.to_time.in_time_zone('Asia/Tokyo')).iso8601
 end
+
+estimates = []
 20.times do
   scheduled = (jst_today + rand(-7..7)).to_datetime.change({ hour: [9, 11, 13, 15].sample, min: [0, 30].sample })
-  c = customers.sample
-  status = ["scheduled","completed","cancelled"].sample
-  accepted = case status
-             when "completed"
-               [true, false].sample
-             when "cancelled"
-               false
-             else
-               nil
-             end
-  price_cents = case status
-                when "completed"
-                  accepted ? [12000, 30000, 58000].sample : nil
-                else
-                  nil
-                end
+  customer = customers.sample
   
-  # accepted = true の場合はプロジェクトを作成
-  project = nil
-  if accepted
-    project = Project.create!(
-      customer: c,
-      title: "#{c.name}様 #{['障子','襖','網戸'].sample} #{[2,3,4,6].sample}枚",
-      status: "in_progress",
-      due_on: jst_today + rand(1..14)
-    )
-  end
+  # 見積の状態を決定（最初は全てscheduled）
+  status = "scheduled"
+  accepted = nil
+  price_cents = nil
   
-  Estimate.create!(
+  # 見積を作成
+  estimate = Estimate.create!(
     scheduled_at: jst_iso(scheduled),
-    customer_id: c.id,
-    project_id: project&.id,
+    customer: customer,
+    project_id: nil,
     customer_snapshot: {
-      name: c.name,
-      phone: c.phone || "090-0000-0000",
-      address: c.address || "大分市"
+      name: customer.name,
+      phone: customer.phone || "090-0000-0000",
+      address: customer.address || "大分市"
     },
     status: status,
     accepted: accepted,
     price_cents: price_cents
   )
+  
+  # 見積項目を作成（1〜3行）
+  rand(1..3).times do
+    material = materials.sample
+    EstimateItem.create!(
+      estimate: estimate,
+      material: material,
+      material_name: material.name,
+      qty: [0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0].sample,
+      unit: material.unit,
+      category: ["障子", "襖", "網戸", "カーテン", "その他"].sample,
+      position: rand(0..10)
+    )
+  end
+  
+  estimates << estimate
 end
 
-# ---- 進行中プロジェクト + タスク + 納品
-say "Create in_progress projects + tasks + deliveries"
-30.times do
-  c = customers.sample
+# ---- プロジェクト（見積成立後のみ作成）
+say "Create projects from accepted estimates"
+projects = []
+
+# 一部の見積を成立状態に変更
+estimates.sample(8).each do |estimate|
+  # プロジェクトを作成
+  project = Project.create!(
+    customer: estimate.customer,
+    title: "#{estimate.customer.name}様 #{['障子','襖','網戸','カーテン'].sample} #{[2,3,4,6,8].sample}枚",
+    status: "in_progress",
+    due_on: jst_today + rand(1..14)
+  )
+  
+  projects << project
+  
+  # 見積を成立状態に更新
+  estimate.update!(
+    status: "completed",
+    accepted: true,
+    project: project,
+    price_cents: [12000, 30000, 58000, 45000, 75000].sample
+  )
+  
+  # 納品予定を作成
+  Delivery.create!(
+    project: project,
+    date: project.due_on,
+    status: "pending",
+    title: "納品",
+    scheduled_at: project.due_on.to_datetime.change({ hour: 10, min: 0 })
+  )
+  
+  # タスクを作成（1〜3個）
+  rand(1..3).times do
+    task = Task.create!(
+      project: project,
+      title: ["障子 張替", "襖 張替", "網戸 張替", "カーテン 取付"].sample + " #{rand(1..5)}枚",
+      kind: ["work", "repair", "replace", "install"].sample,
+      status: ["todo", "doing"].sample,
+      due_on: project.due_on + rand(-2..2)
+    )
+    
+    # タスク材料を作成（1〜2行）
+    rand(1..2).times do
+      material = materials.sample
+      qty_planned = [0.5, 1.0, 1.5, 2.0, 3.0, 4.0].sample
+      
+      TaskMaterial.create!(
+        task: task,
+        material: material,
+        material_name: material.name,
+        qty_planned: qty_planned,
+        qty_used: 0.0 # 未完了タスクは使用量0
+      )
+    end
+  end
+end
+
+# 一部の見積を不成立状態に変更
+estimates.sample(5).each do |estimate|
+  next if estimate.project_id.present? # 既にプロジェクトが紐づいているものは除外
+  
+  estimate.update!(
+    status: "completed",
+    accepted: false,
+    price_cents: nil
+  )
+end
+
+# ---- 独立したプロジェクト（見積なし）
+say "Create independent projects"
+10.times do
+  customer = customers.sample
   due_on = jst_today + rand(0..10)
-  p = Project.create!(
-    customer: c,
-    title: "#{c.name}様 #{['障子','襖','網戸'].sample} #{[2,3,4,6].sample}枚",
+  
+  project = Project.create!(
+    customer: customer,
+    title: "#{customer.name}様 #{['障子','襖','網戸','カーテン'].sample} #{[2,3,4,6].sample}枚",
     status: "in_progress",
     due_on: due_on
   )
-
-  # 納品（pending）
+  
+  projects << project
+  
+  # 納品予定
   Delivery.create!(
-    project: p,
+    project: project,
     date: due_on,
     status: "pending",
-    title: "納品"
+    title: "納品",
+    scheduled_at: due_on.to_datetime.change({ hour: 10, min: 0 })
   )
-
-  # タスク 1〜3
+  
+  # タスク（1〜3個）
   rand(1..3).times do
-    t = Task.create!(
-      project: p,
-      title: ["障子 張替", "襖 張替", "網戸 張替"].sample + " #{[1,2,3].sample}枚",
-      kind: ["work", "repair", "replace"].sample,
-      status: ["todo","doing"].sample,
-      due_on: due_on
+    task = Task.create!(
+      project: project,
+      title: ["障子 張替", "襖 張替", "網戸 張替", "カーテン 取付"].sample + " #{rand(1..5)}枚",
+      kind: ["work", "repair", "replace", "install"].sample,
+      status: ["todo", "doing"].sample,
+      due_on: due_on + rand(-2..2)
     )
-    # 材料 1〜2行
+    
+    # タスク材料
     rand(1..2).times do
-      m = materials.sample
+      material = materials.sample
+      qty_planned = [0.5, 1.0, 1.5, 2.0, 3.0].sample
+      
       TaskMaterial.create!(
-        task: t,
-        material: m,
-        material_name: m.name,
-        qty_planned: [1,2,3,4].sample
+        task: task,
+        material: material,
+        material_name: material.name,
+        qty_planned: qty_planned,
+        qty_used: 0.0
       )
     end
   end
 end
 
-# ---- 完了済みプロジェクト（在庫も減算されるようサービスで完了させる）
-say "Create completed projects (via service)"
-10.times do
-  c = customers.sample
-  due_on = jst_today - rand(0..14) # 過去〜直近
-  p = Project.create!(
-    customer: c,
-    title: "#{c.name}様 #{['障子','襖','網戸'].sample} 完了案件",
+# ---- 完了済みプロジェクト（在庫管理の整合性を保つ）
+say "Create completed projects with proper inventory management"
+5.times do
+  customer = customers.sample
+  due_on = jst_today - rand(1..14) # 過去の日付
+  
+  project = Project.create!(
+    customer: customer,
+    title: "#{customer.name}様 #{['障子','襖','網戸'].sample} 完了案件",
     status: "delivery_scheduled",
     due_on: due_on
   )
-  # 納品（pending）
-  Delivery.create!(project: p, date: due_on, status: "pending", title: "納品")
-
-  # タスク 2〜3 を done & prepared にして材料紐付け
-  2.times do
-    t = Task.create!(
-      project: p,
-      title: ["障子 張替 2枚","襖 張替 2枚","網戸 張替 2枚"].sample,
+  
+  projects << project
+  
+  # 納品（完了）
+  Delivery.create!(
+    project: project, 
+    date: due_on, 
+    status: "delivered", 
+    title: "納品",
+    scheduled_at: due_on.to_datetime.change({ hour: 10, min: 0 })
+  )
+  
+  # 完了済みタスク（在庫減算済み）
+  rand(2..3).times do
+    task = Task.create!(
+      project: project,
+      title: ["障子 張替", "襖 張替", "網戸 張替"].sample + " #{rand(1..3)}枚",
       kind: "work",
       status: "done",
       due_on: due_on,
-      prepared_at: Time.current
-    )
-    # 材料 1〜2行 + 実使用数
-    rand(1..2).times do
-      m = materials.sample
-      planned = [1,2,3].sample
-      TaskMaterial.create!(
-        task: t,
-        material: m,
-        material_name: m.name,
-        qty_planned: planned,
-        qty_used: planned
-      )
-    end
-  end
-
-  # 案件完了（在庫減算・納品 delivered 化・監査ログ）
-  if defined?(Projects::CompleteService)
-    Projects::CompleteService.call(project_id: p.id)
-  else
-    # フォールバック（サービスがなければ最低限の状態変更）
-    p.update!(status: "completed")
-    Delivery.where(project_id: p.id, status: "pending").update_all(status: "delivered")
-  end
-end
-
-# ---- 何件かのタスクは seed 時点で "完了→在庫減" にしておく
-say "Complete some tasks (inventory down)"
-if defined?(Tasks::CompleteService)
-  Task.where(status: %w[todo doing]).limit(15).find_each do |t|
-    begin
-      Tasks::CompleteService.call(task_id: t.id)
-    rescue => e
-      # 在庫不足などは無視して続行
-    end
-  end
-end
-
-# ---- フロントエンドテスト用の追加タスクデータ
-say "Create additional tasks for frontend testing"
-customers.first(5).each do |c|
-  # 各顧客に2件のプロジェクト（進行中）
-  rand(1..2).times do
-    due_on = jst_today + rand(1..7) # 1週間以内
-    p = Project.create!(
-      customer: c,
-      title: "#{c.name}様 #{['障子','襖','網戸','カーテン'].sample} #{rand(1..5)}枚",
-      status: "in_progress",
-      due_on: due_on
+      prepared_at: due_on.to_datetime.change({ hour: 16, min: 0 })
     )
     
-    # 各プロジェクトに2〜4件のタスク（todo/doneが半々）
-    rand(2..4).times do
-      status = rand < 0.5 ? "todo" : "done"
-      t = Task.create!(
-        project: p,
-        title: ["障子 張替", "襖 張替", "網戸 張替", "カーテン 取付"].sample + " #{rand(1..5)}枚",
-        kind: "work",
-        status: status,
-        due_on: due_on + rand(-2..2), # プロジェクト期日の前後2日
-        prepared_at: status == "done" ? Time.current : nil
-      )
+    # 材料（使用量を設定して在庫減算）
+    rand(1..2).times do
+      material = materials.sample
+      qty_used = [0.5, 1.0, 1.5, 2.0].sample
       
-      # 各タスクに1〜3件の材料
-      rand(1..3).times do
-        m = materials.sample
-        planned = [0.5, 1.0, 1.5, 2.0, 3.0].sample
-        used = status == "done" ? planned : 0  # 完了タスクは使用量、未完了タスクは0
-        TaskMaterial.create!(
-          task: t,
-          material: m,
-          material_name: m.name,
-          qty_planned: planned,
-          qty_used: used
-        )
-      end
+      # 在庫から減算
+      material.update!(current_qty: material.current_qty - qty_used)
+      
+      TaskMaterial.create!(
+        task: task,
+        material: material,
+        material_name: material.name,
+        qty_planned: qty_used,
+        qty_used: qty_used
+      )
     end
+  end
+  
+  # プロジェクト完了
+  project.update!(status: "completed", completed_at: due_on.to_datetime.change({ hour: 17, min: 0 }))
+end
+
+# ---- 一部のタスクを完了状態に（在庫管理の整合性を保つ）
+say "Complete some tasks with inventory management"
+Task.where(status: %w[todo doing]).limit(10).find_each do |task|
+  # 在庫チェック
+  can_complete = true
+  insufficient_materials = []
+  
+  task.task_materials.each do |tm|
+    qty = tm.effective_qty_for_inventory
+    next unless qty > 0
+    
+    material = tm.material
+    next unless material
+    
+    if material.current_qty < qty
+      can_complete = false
+      insufficient_materials << "#{material.name}（必要:#{qty}、在庫:#{material.current_qty}）"
+    end
+  end
+  
+  if can_complete
+    # 在庫減算
+    task.task_materials.each do |tm|
+      qty = tm.effective_qty_for_inventory
+      next unless qty > 0
+      
+      material = tm.material
+      next unless material
+      
+      material.update!(current_qty: material.current_qty - qty)
+      tm.update!(qty_used: qty)
+    end
+    
+    # タスク完了
+    task.update!(
+      status: "done", 
+      prepared_at: Time.current
+    )
+    
+    # 監査ログ
+    changes = task.task_materials.filter_map do |tm|
+      q = tm.effective_qty_for_inventory
+      next if q <= 0
+      name = tm.material&.name || tm.material_name
+      "#{name} -#{q.to_s('F')}"
+    end
+    
+    summary = changes.present? ? "タスク完了（在庫: #{changes.join(' / ')}）" : "タスク完了"
+    
+    AuditLog.create!(
+      action: "task.complete", 
+      target_type: "task", 
+      target_id: task.id, 
+      summary: summary,
+      inverse: { method: "POST", path: "/api/tasks/#{task.id}/revert-complete", payload: {} }
+    )
   end
 end
 
-# ---- E2Eテスト用の固定シナリオ
-say "Create E2E test scenario"
-e2e_customer = Customer.create!(
-  name: "E2Eテスト顧客",
-  phone: "090-E2E-TEST",
-  address: "E2Eテスト住所"
+# ---- 顧客メモ
+say "Create customer memos"
+customers.sample(15).each do |customer|
+  rand(1..3).times do
+    CustomerMemo.create!(
+      customer: customer,
+      body: [
+        "お客様からの要望：#{['早めの納品', '品質重視', '価格重視', 'アフターサービス'].sample}",
+        "連絡事項：#{['電話連絡済み', 'メール送信済み', '訪問予定', '見積もり検討中'].sample}",
+        "特記事項：#{['高齢者対応', 'ペット対応', '駐車場確保', '騒音対策'].sample}"
+      ].sample
+    )
+  end
+end
+
+# ---- 写真データ（プロジェクト用）
+say "Create project photos"
+projects.sample(8).each do |project|
+  rand(1..3).times do
+    Photo.create!(
+      project: project,
+      kind: ["before", "after", "other"].sample,
+      blob_key: "dummy_photo_#{SecureRandom.hex(8)}",
+      filename: "#{project.title}_#{['before', 'after', 'work'].sample}.jpg",
+      content_type: "image/jpeg",
+      byte_size: rand(100000..5000000)
+    )
+  end
+end
+
+# ---- 在庫不足のテストケース
+say "Create low stock test cases"
+low_stock_material = Material.find_by(name: "障子紙（標準）")
+low_stock_material.update!(current_qty: 3.0) # threshold_qty=15より少ない
+
+# この材料を使用するタスクを作成（完了時に在庫不足エラーが発生する）
+test_customer = Customer.create!(
+  name: "テスト顧客（在庫不足）",
+  phone: "090-TEST-STOCK",
+  address: "テスト住所"
 )
 
-# 障子紙（標準）の在庫を少なくして不足状態を作る
-e2e_material = Material.find_by(name: "障子紙（標準）")
-e2e_material.update!(current_qty: 5.0) # threshold_qty=15 より少ない
-
-# 見積：障子紙（標準）を20枚必要とする（在庫不足）
-e2e_estimate = Estimate.create!(
-  scheduled_at: jst_iso(jst_today), # 今日の日付に変更
-  customer: e2e_customer,
-  status: "scheduled",
-  accepted: nil
-)
-
-EstimateItem.create!(
-  estimate: e2e_estimate,
-  material: e2e_material,
-  material_name: e2e_material.name,
-  quantity: 20.0
-)
-
-# タスク：障子紙（標準）を5枚使用予定（完了で在庫がさらに減る）
-e2e_project = Project.create!(
-  customer: e2e_customer,
-  title: "E2Eテスト案件",
+test_project = Project.create!(
+  customer: test_customer,
+  title: "テスト案件（在庫不足）",
   status: "in_progress",
   due_on: jst_today + 3
 )
 
-e2e_task = Task.create!(
-  project: e2e_project,
-  title: "E2Eテストタスク",
+test_task = Task.create!(
+  project: test_project,
+  title: "障子 張替 5枚",
   kind: "work",
   status: "todo",
   due_on: jst_today + 3
 )
 
 TaskMaterial.create!(
-  task: e2e_task,
-  material: e2e_material,
-  material_name: e2e_material.name,
+  task: test_task,
+  material: low_stock_material,
+  material_name: low_stock_material.name,
   qty_planned: 5.0,
   qty_used: 0.0
 )
 
-say "E2E test scenario created:"
-puts "  Customer: #{e2e_customer.name} (ID: #{e2e_customer.id})"
-puts "  Material: #{e2e_material.name} (ID: #{e2e_material.id}, current: #{e2e_material.current_qty}, threshold: #{e2e_material.threshold_qty})"
-puts "  Estimate: ID #{e2e_estimate.id}, needs #{e2e_material.name} 20#{e2e_material.unit}"
-puts "  Task: ID #{e2e_task.id}, will use #{e2e_material.name} 5#{e2e_material.unit}"
-
+# ---- 完了
 say "Done."
 puts
 puts "Counts:"
@@ -312,4 +415,11 @@ puts "  Projects  : #{Project.count} (completed: #{Project.where(status: 'comple
 puts "  Tasks     : #{Task.count} (todo: #{Task.where(status: 'todo').count}, done: #{Task.where(status: 'done').count})"
 puts "  Deliveries: #{Delivery.count} (pending: #{Delivery.where(status: 'pending').count}, delivered: #{Delivery.where(status: 'delivered').count})"
 puts "  Estimates : #{Estimate.count}"
+puts "  EstimateItems: #{EstimateItem.count}"
 puts "  TaskMaterials: #{TaskMaterial.count}"
+puts "  CustomerMemos: #{CustomerMemo.count}"
+puts "  Photos: #{Photo.count}"
+puts
+puts "Test Cases:"
+puts "  Low stock material: #{low_stock_material.name} (current: #{low_stock_material.current_qty}, threshold: #{low_stock_material.threshold_qty})"
+puts "  Test task ID: #{test_task.id} (will fail completion due to insufficient stock)"

--- a/frontend/src/app/(pages)/projects/page.tsx
+++ b/frontend/src/app/(pages)/projects/page.tsx
@@ -115,7 +115,12 @@ export default function ProjectsPage() {
                       hour12: false,
                     })}
                   </div>
-                  <div className="font-medium">{estimate.customerName || '（無名）'}</div>
+                  <div className="font-medium">
+                    {estimate.customerName ||
+                      estimate.customer?.name ||
+                      estimate.customer_snapshot?.name ||
+                      '（無名）'}
+                  </div>
                 </li>
               ))}
               {groupedEstimates.today.length > 3 && (
@@ -141,7 +146,12 @@ export default function ProjectsPage() {
                       hour12: false,
                     })}
                   </div>
-                  <div className="font-medium">{estimate.customerName || '（無名）'}</div>
+                  <div className="font-medium">
+                    {estimate.customerName ||
+                      estimate.customer?.name ||
+                      estimate.customer_snapshot?.name ||
+                      '（無名）'}
+                  </div>
                 </li>
               ))}
               {groupedEstimates.tomorrow.length > 3 && (
@@ -168,7 +178,12 @@ export default function ProjectsPage() {
                       day: 'numeric',
                     })}
                   </div>
-                  <div className="font-medium">{estimate.customerName || '（無名）'}</div>
+                  <div className="font-medium">
+                    {estimate.customerName ||
+                      estimate.customer?.name ||
+                      estimate.customer_snapshot?.name ||
+                      '（無名）'}
+                  </div>
                 </li>
               ))}
               {groupedEstimates.later.length > 3 && (

--- a/frontend/src/app/_components/estimate/EstimateItemRow.tsx
+++ b/frontend/src/app/_components/estimate/EstimateItemRow.tsx
@@ -146,20 +146,28 @@ export function EstimateItemRow({
 
         {/* 材料選択 */}
         <div className="md:col-span-4">
-          {showMaterialPicker ? (
-            <MaterialPicker
-              value={localItem.materialId || null}
-              onChange={handleMaterialChange}
-              availability={availability}
-              placeholder="材料を選択または入力"
-            />
-          ) : hasSelectedMaterial ? (
+          {!item.category ? (
+            // カテゴリーが未選択の場合
+            <div className="text-gray-500 text-sm italic">カテゴリーを選択してください</div>
+          ) : item.materialId ? (
+            // 材料が選択済みの場合
             <div className="space-y-2">
-              {/* 選択中材料の表示 */}
               <div className="p-3 bg-green-50 border border-green-200 rounded-md">
                 <div className="flex items-center justify-between">
                   <div className="flex-1">
-                    <div className="text-green-800 font-medium">{item.materialName}</div>
+                    <div className="text-green-800 font-medium">
+                      <input
+                        type="text"
+                        value={localItem.materialName}
+                        onChange={(e) => {
+                          const updated = { ...localItem, materialName: e.target.value };
+                          setLocalItem(updated);
+                          onUpdate(updated);
+                        }}
+                        className="bg-transparent border-none p-0 text-green-800 font-medium focus:outline-none focus:ring-1 focus:ring-green-300 rounded px-1"
+                        placeholder="材料名を入力"
+                      />
+                    </div>
                     {selectedMaterial && (
                       <div className="text-green-600 text-sm mt-1">
                         在庫: {selectedMaterial.availableQty} / 予定消費:{' '}
@@ -181,10 +189,48 @@ export function EstimateItemRow({
                 </div>
               </div>
             </div>
-          ) : item.category ? (
-            <div className="text-gray-500 text-sm italic">材料を選択してください</div>
+          ) : item.materialName && !item.materialId ? (
+            // 自由入力済みの場合
+            <div className="space-y-2">
+              <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-md">
+                <div className="flex items-center justify-between">
+                  <div className="flex-1">
+                    <div className="text-yellow-800 font-medium">
+                      <input
+                        type="text"
+                        value={localItem.materialName}
+                        onChange={(e) => {
+                          const updated = { ...localItem, materialName: e.target.value };
+                          setLocalItem(updated);
+                          onUpdate(updated);
+                        }}
+                        className="bg-transparent border-none p-0 text-yellow-800 font-medium focus:outline-none focus:ring-1 focus:ring-yellow-300 rounded px-1"
+                        placeholder="材料名を入力"
+                      />
+                    </div>
+                    <div className="text-yellow-600 text-sm mt-1">自由入力（在庫不明）</div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleMaterialClear}
+                      className="px-2 py-1 text-xs bg-red-100 hover:bg-red-200 text-red-800 rounded border border-red-300 transition-colors"
+                    >
+                      クリア
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
           ) : (
-            <div className="text-gray-500 text-sm italic">カテゴリーを選択してください</div>
+            // カテゴリー選択済みで材料未選択の場合
+            <div className="space-y-2">
+              <MaterialPicker
+                value={localItem.materialId || null}
+                onChange={handleMaterialChange}
+                availability={availability}
+                placeholder="材料を選択または入力"
+              />
+            </div>
           )}
         </div>
 

--- a/frontend/src/app/_components/estimate/MaterialPicker.tsx
+++ b/frontend/src/app/_components/estimate/MaterialPicker.tsx
@@ -37,17 +37,26 @@ export function MaterialPicker({
       material.name.includes(searchTerm),
   );
 
+  const handleCustomInput = (input: string) => {
+    setCustomInput(input);
+    // 入力内容を常に更新（空文字列でも）
+    onChange(null, input);
+  };
+
+  const handleSearchChange = (input: string) => {
+    setSearchTerm(input);
+    // 検索フィールドでも自由入力を可能にする
+    if (input && !availability.find((m) => m.name.toLowerCase() === input.toLowerCase())) {
+      setCustomInput(input);
+      onChange(null, input);
+    }
+  };
+
   const handleMaterialSelect = (material: MaterialsAvailabilityItem) => {
     onChange(material.id, material.name, material.unit || undefined, undefined);
     setCustomInput('');
+    setSearchTerm(material.name); // 選択された材料名を検索フィールドに表示
     setIsOpen(false);
-  };
-
-  const handleCustomInput = (input: string) => {
-    setCustomInput(input);
-    if (input.trim()) {
-      onChange(null, input.trim());
-    }
   };
 
   const handleClear = () => {
@@ -59,14 +68,15 @@ export function MaterialPicker({
   return (
     <div className="relative">
       <div className="flex gap-2">
-        {/* 材料選択ドロップダウン */}
+        {/* 統合された材料選択・自由入力フィールド */}
         <div className="relative flex-1">
           <input
             type="text"
             placeholder={placeholder}
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => handleSearchChange(e.target.value)}
             onFocus={() => setIsOpen(true)}
+            onBlur={() => setTimeout(() => setIsOpen(false), 200)} // 少し遅延させて選択可能にする
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           />
 
@@ -88,24 +98,17 @@ export function MaterialPicker({
                     )}
                   </div>
                 ))
+              ) : searchTerm ? (
+                <div className="px-3 py-2 text-gray-500">「{searchTerm}」で自由入力として使用</div>
               ) : (
-                <div className="px-3 py-2 text-gray-500">材料が見つかりません</div>
+                <div className="px-3 py-2 text-gray-500">材料を選択または入力してください</div>
               )}
             </div>
           )}
         </div>
 
-        {/* カスタム入力 */}
-        <input
-          type="text"
-          placeholder="自由入力"
-          value={customInput}
-          onChange={(e) => handleCustomInput(e.target.value)}
-          className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-        />
-
         {/* クリアボタン */}
-        {(selectedMaterial || customInput) && (
+        {(selectedMaterial || searchTerm) && (
           <button
             onClick={handleClear}
             className="px-3 py-2 text-gray-500 hover:text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
@@ -128,11 +131,11 @@ export function MaterialPicker({
         </div>
       )}
 
-      {/* カスタム入力の情報表示 */}
-      {customInput && !selectedMaterial && (
+      {/* 自由入力の情報表示 */}
+      {searchTerm && !selectedMaterial && (
         <div className="mt-2 p-2 bg-yellow-50 border border-yellow-200 rounded text-sm">
           <div className="text-yellow-800">
-            <span className="font-medium">カスタム入力:</span> {customInput}
+            <span className="font-medium">自由入力:</span> {searchTerm}
           </div>
           <div className="text-yellow-600 mt-1">在庫不明（材料マスターに登録されていません）</div>
         </div>


### PR DESCRIPTION
- 在庫不足チェックサービスの複数タスク対応
- ダミーデータの整合性向上（在庫管理対応）
- 見積もり予定表示での顧客名表示改善
- 見積もり材料選択UIの改善（カテゴリー別表示制御）
- 材料選択・自由入力の統合と入力処理の改善

## 概要
<!-- 何を・なぜやるのかを1〜3行で -->

## 背景
<!-- 課題/要件・関連Issue/経緯など -->

## 変更点
<!-- 主要な変更を箇条書きで -->
- 

## 実装詳細
<!-- アーキ/責務分担/影響範囲（DB/外部API/設定）など -->

## テスト観点
<!-- 観点→手順→期待結果。スクショ/ログ/動画リンクがあれば -->
- 観点:
- 手順:
- 期待結果:

## リスク・影響
<!-- 既存機能への影響/ロールバック手順/移行手順など -->

## 動作確認
- [ ] ローカルで基本動作確認
- [ ] エラー時のハンドリング確認
- [ ] パフォーマンス影響確認（必要なら）
- [ ] セキュリティ観点（RLS/認可など）確認

## 関連
<!-- Close #123 のように書くとマージ時に自動クローズ -->
- Close #

## メモ
<!-- レビュアーへの補足、注意点 -->
